### PR TITLE
CWA Parent 1.7

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -29,6 +29,12 @@
         <notes>Keycloak Update is currently not possible</notes>
         <cve>CVE-2022-1245</cve>
         <cve>CVE-2022-2668</cve>
+        <cve>CVE-2021-3827</cve>
+    </suppress>
+
+    <suppress>
+        <notes>SnakeYML False Positive Matcher (CVE is up to 1.32, but also matches for 1.33)</notes>
+        <cve>CVE-2022-38752</cve>
     </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,26 +59,46 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.2</version>
+                <version>2.7.4</version><!-- Also update version of Spring Boot in Spring Boot Plugin -->
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.yaml</groupId>
+                        <artifactId>snakeyaml</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.33</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.14.0-rc2</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2021.0.3</version>
+                <version>2021.0.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-openfeign</artifactId>
-                <version>3.1.3</version>
+                <version>3.1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>
-                <version>1.6.9</version>
+                <version>1.6.11</version>
             </dependency>
 
 
@@ -94,12 +114,12 @@
             <dependency>
                 <groupId>net.javacrumbs.shedlock</groupId>
                 <artifactId>shedlock-spring</artifactId>
-                <version>4.37.0</version>
+                <version>4.42.0</version>
             </dependency>
             <dependency>
                 <groupId>net.javacrumbs.shedlock</groupId>
                 <artifactId>shedlock-provider-jdbc-template</artifactId>
-                <version>4.39.0</version>
+                <version>4.42.0</version>
             </dependency>
 
             <!-- Commons IO -->
@@ -136,7 +156,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.23</version>
+                <version>9.25.5</version>
             </dependency>
 
 
@@ -144,7 +164,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>4.14.0</version>
+                <version>4.17.0</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -156,6 +176,11 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>42.4.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>42.5.0</version>
             </dependency>
 
 
@@ -179,7 +204,7 @@
             <dependency>
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
-                <version>2.0.26</version>
+                <version>2.0.27</version>
             </dependency>
 
 
@@ -200,7 +225,7 @@
             <dependency>
                 <groupId>com.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
-                <version>5.6</version>
+                <version>5.7.0</version>
             </dependency>
 
 
@@ -218,12 +243,12 @@
             <dependency>
                 <groupId>com.c4-soft.springaddons</groupId>
                 <artifactId>spring-security-oauth2-test-addons</artifactId>
-                <version>3.1.15-jdk11</version>
+                <version>3.1.19-jdk11</version>
             </dependency>
             <dependency>
                 <groupId>com.c4-soft.springaddons</groupId>
                 <artifactId>spring-security-oauth2-test-webmvc-addons</artifactId>
-                <version>3.1.15-jdk11</version>
+                <version>3.1.19-jdk11</version>
             </dependency>
 
 
@@ -238,19 +263,19 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
-                <version>1.12.272</version>
+                <version>1.12.319</version>
             </dependency>
 
             <!-- SAP Cloud Foundry -->
             <dependency>
                 <groupId>io.pivotal.cfenv</groupId>
                 <artifactId>java-cfenv-boot</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.1</version>
             </dependency>
             <dependency>
                 <groupId>com.sap.cloud.sdk.cloudplatform</groupId>
                 <artifactId>scp-cf</artifactId>
-                <version>3.73.0</version>
+                <version>3.75.0</version>
             </dependency>
             <dependency>
                 <groupId>com.sap.hcp.cf.logging</groupId>
@@ -262,7 +287,7 @@
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
-                <version>1.5.2.Final</version><!-- Also update version of lombok in Maven Compiler Plugin -->
+                <version>1.5.3.Final</version><!-- Also update version of lombok in Maven Compiler Plugin -->
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -273,7 +298,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.7.2</version>
+                    <version>2.7.4</version>
                     <executions>
                         <execution>
                             <goals>
@@ -304,7 +329,7 @@
                             <path>
                                 <groupId>org.mapstruct</groupId>
                                 <artifactId>mapstruct-processor</artifactId>
-                                <version>1.5.2.Final</version>
+                                <version>1.5.3.Final</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
@@ -313,11 +338,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                     <configuration>
                         <configLocation>codestyle/checkstyle.xml</configLocation>
                         <excludes>target/**/*</excludes>
-                        <encoding>UTF-8</encoding>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
                         <violationSeverity>warning</violationSeverity>
@@ -379,7 +403,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>7.1.1</version>
+                    <version>7.2.1</version>
                     <configuration>
                         <suppressionFile>./owasp/suppressions.xml</suppressionFile>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>

--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,6 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.4.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.postgresql</groupId>
-                <artifactId>postgresql</artifactId>
                 <version>42.5.0</version>
             </dependency>
 


### PR DESCRIPTION
Update Dependencies and Update OWASP Suppressions:

* Update Spring Boot to 2.7.4
* Update Spring Cloud Dependencies to 2021.0.4
* Update Spring Cloud Starter OpenFeign to 3.1.4
* Force version 2.14.0-rc2 of Jackson Databind because of open CVE
* Update SpringDoc OpenAPI UI to 1.6.11
* Update Shedlock to 4.42.0
* Update Nimbus Jose JWT to 9.25.5
* Update Liquibase to 4.17.0
* Update Psql-Driver to 42.5.0
* Update PDF-Box to 2.0.27
* Update OpenCSV to 5.7.0
* Update spring-security-oauth2-test-addons to 3.1.19
* Update AWS S3 SDK to 1.12.319
* Update SAP CF to 3.75.0
* Update CloudFoundry to 2.4.1
* Update Mapstruct to 1.5.3.Final
* Update Checkstyle Plugin to 3.2.0
* Update Dependency Check Plugin to 7.2.1