### PR TITLE
Update Keycloak to 20.0.1 and more dependency updates

### DIFF
--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -2,14 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
     <suppress>
-        <notes>Updating of Keycloak Lib is not possible at the moment. Security risk is not affecting CWA components.</notes>
-        <cve>CVE-2022-1466</cve>
-        <cve>CVE-2022-1970</cve>
-        <cve>CVE-2021-20323</cve>
-        <cve>CVE-2020-14359</cve>
-    </suppress>
-
-    <suppress>
         <notes>CVE is matching for Spring Security 5.3.x, but we have 5.7.x</notes>
         <cve>CVE-2020-5408</cve>
     </suppress>
@@ -23,13 +15,6 @@
         <notes>False Positive matches</notes>
         <cve>CVE-2022-31514</cve>
         <cve>CVE-2022-2393</cve>
-    </suppress>
-    
-    <suppress>
-        <notes>Keycloak Update is currently not possible</notes>
-        <cve>CVE-2022-1245</cve>
-        <cve>CVE-2022-2668</cve>
-        <cve>CVE-2021-3827</cve>
     </suppress>
 
     <suppress>

--- a/owasp/suppressions.xml
+++ b/owasp/suppressions.xml
@@ -22,4 +22,15 @@
         <cve>CVE-2022-38752</cve>
     </suppress>
 
+    <suppress>
+        <notes>This CVE is only affecting Keycloak Server not the Lib. (https://bugzilla.redhat.com/show_bug.cgi?id=2141404)</notes>
+        <cve>CVE-2022-3916</cve>
+    </suppress>
+
+    <suppress>
+        <notes>The affected libs are just used for unit-testing.</notes>
+        <cve>CVE-2022-31690</cve>
+        <cve>CVE-2022-31692</cve>
+    </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -239,12 +239,12 @@
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-spring-boot-starter</artifactId>
-                <version>15.1.1</version>
+                <version>20.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-client</artifactId>
-                <version>15.1.1</version>
+                <version>20.0.1</version>
             </dependency>
             <dependency>
                 <groupId>com.c4-soft.springaddons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,16 @@
                         <groupId>org.yaml</groupId>
                         <artifactId>snakeyaml</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-core</artifactId>
+                    </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-core</artifactId>
+                <version>5.7.5</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.4</version><!-- Also update version of Spring Boot in Spring Boot Plugin -->
+                <version>2.7.5</version><!-- Also update version of Spring Boot in Spring Boot Plugin -->
                 <type>pom</type>
                 <scope>import</scope>
                 <exclusions>
@@ -81,24 +81,24 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.14.0-rc2</version>
+                <version>2.14.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2021.0.4</version>
+                <version>2021.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-openfeign</artifactId>
-                <version>3.1.4</version>
+                <version>3.1.5</version>
             </dependency>
             <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>
-                <version>1.6.11</version>
+                <version>1.6.12</version>
             </dependency>
 
 
@@ -156,7 +156,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.25.5</version>
+                <version>9.25.6</version>
             </dependency>
 
 
@@ -164,7 +164,7 @@
             <dependency>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-core</artifactId>
-                <version>4.17.0</version>
+                <version>4.17.2</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>eu.europa.ec.dgc</groupId>
                 <artifactId>dgc-lib</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.3</version>
             </dependency>
 
 
@@ -212,7 +212,7 @@
             <dependency>
                 <groupId>com.google.zxing</groupId>
                 <artifactId>javase</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
             </dependency>
 
 
@@ -220,20 +220,8 @@
             <dependency>
                 <groupId>com.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
-                <version>5.7.0</version> <!-- When updating to > 5.7.0 remove exclusion of commons-text -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-text</artifactId>
-                    </exclusion>
-                </exclusions>
+                <version>5.7.1</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-text</artifactId>
-                <version>[1.10.0)</version>
-            </dependency>
-
 
             <!-- Keycloak -->
             <dependency>
@@ -269,7 +257,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
-                <version>1.12.319</version>
+                <version>1.12.344</version>
             </dependency>
 
             <!-- SAP Cloud Foundry -->
@@ -293,7 +281,7 @@
             <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
-                <version>1.5.3.Final</version><!-- Also update version of lombok in Maven Compiler Plugin -->
+                <version>1.5.3.Final</version><!-- Also update version of Mapstruct in Maven Compiler Plugin -->
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -304,7 +292,7 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>2.7.4</version>
+                    <version>2.7.5</version>
                     <executions>
                         <execution>
                             <goals>
@@ -409,7 +397,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>7.2.1</version>
+                    <version>7.3.1</version>
                     <configuration>
                         <suppressionFile>./owasp/suppressions.xml</suppressionFile>
                         <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
                         <groupId>org.springframework.security</groupId>
                         <artifactId>spring-security-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-web</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-config</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -82,6 +94,22 @@
                 <artifactId>spring-security-core</artifactId>
                 <version>5.7.5</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-web</artifactId>
+                <version>5.7.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-config</artifactId>
+                <version>5.7.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-crypto</artifactId>
+                <version>5.7.5</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
Update Keycloak to 20.0.1
Update Spring Boot to 2.7.5

Update Jackson Databind to 2.14.0
Update Spring Cloud Starter Openfeign to 3.1.5
Update Springdoc OpenAPI UI to 1.6.12
Update Nimbus Jose JWT to 9.25.6
Update Liquibase to 4.17.2
Update DGC-Lib to 1.3.3
Update Google ZXing to 3.5.1
Update OpenCSV to 5.7.1
Update S3 SDK to 1.12.344
Update OWASP Dependency Check to 7.3.1