### PR TITLE
Fix: Remove Sleuth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-starter-sleuth</artifactId>
-                <version>3.1.6</version>
-            </dependency>
-            <dependency>
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-ui</artifactId>
                 <version>1.6.14</version>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -32,10 +32,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-sleuth</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>


### PR DESCRIPTION
Sleuth was deprecated with Spring Boot 3.0
New Spring Boot Actuator includes integrated log-tracing